### PR TITLE
Upgrade deployment to Maven Central to use new plugin from Sonatype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build on Java ${{ matrix.java }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.6.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -20,36 +20,41 @@ jobs:
         run: mvn -B clean verify --no-transfer-progress --show-version
 
 
-  publishing_parameters:
-    needs: build
-    name: Publishing parameters
-    runs-on: ubuntu-latest
-    outputs:
-      is_release: ${{ steps.version.outputs.is_release }}
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - name: Determine version
-        id: version
-        run: |
-          if [[ $GITHUB_REF == *"tags"* ]]; then
-            is_release=true
-            version=${GITHUB_REF#refs/tags/}
-          else
-            is_release=false
-            version=${GITHUB_REF#refs/heads/}-SNAPSHOT
-          fi
-          echo "is_release=${is_release//\//-}" >> $GITHUB_OUTPUT
-          echo "version=${version//\//-}" >> $GITHUB_OUTPUT
-
-
   publish:
-    needs: publishing_parameters
-    name: Publish ${{ needs.publishing_parameters.outputs.version }}
+    needs: build
+    name: Publish ${{ github.ref_name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: digipost/action-maven-publish@1.3.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          sonatype_secrets: ${{ secrets.sonatype_secrets }}
-          release_version: ${{ needs.publishing_parameters.outputs.version }}
-          perform_release: ${{ needs.publishing_parameters.outputs.is_release }}
+          distribution: temurin
+          java-version: '21'
+          cache: "maven"
+          gpg-private-key: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PRIVATE }}
+          server-id: central
+          server-username: MAVEN_CENTRAL_TOKEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Activate Artifact Signing and Version Suffix
+        run: |
+          profiles="build-sources-and-javadoc,deploy-to-maven-central"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            profiles="$profiles,sign-artifacts"
+            version_suffix=""
+          else
+            version_suffix="-SNAPSHOT"
+          fi
+          echo "MAVEN_PROFILES=$profiles" >> $GITHUB_ENV
+          version="${GITHUB_REF_NAME}${version_suffix}"
+          echo "VERSION=$version" >> $GITHUB_ENV
+      - name: Set Maven version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${VERSION}
+      - name: Build and deploy to Maven Central
+        run: |
+          mvn --batch-mode --no-transfer-progress --activate-profiles ${MAVEN_PROFILES} deploy
+        env:
+          MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PASSPHRASE }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>12</version>
+        <version>14</version>
     </parent>
 
     <artifactId>jul-to-slf4j-junit-extension</artifactId>
@@ -92,11 +92,11 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.14.0</version>
                     <configuration>
                         <compilerArgs>
                             <arg>-Xlint</arg>
@@ -105,40 +105,40 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M9</version>
+                    <version>3.5.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.11.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.15.0</version>
+                    <version>2.18.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Upgrade most plugins to latest release.  Rewrite the publishing job to deploy directly to Maven Central (was: using obsolete GitHub action) with new plugin configured in the  parent POM and using more recent support in setup-java for deployment settings in Maven.